### PR TITLE
Checks for 0-length proof, adds getStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the source code of the CryptoCompare price feed smart contract designed to work as a module for the Melonport's Melon protocol.
 
-The contract is now live on Kovan: https://kovan.etherscan.io/address/0x5cc7f6b7d0f4b05acf3b186d540a3ec24cada5ae
+The contract is now live on Kovan: https://kovan.etherscan.io/address/0x15eB26AAAB14fdE0e4c041cD9e0Dfe484872C2eA 
 
 It continuously fetches data from the CryptoCompare WebAPIs through Oraclize to provide on-chain references of the BTC, EUR, REP, MLN exchange rates against ETH. Compared to the existing Oraclize module, you get the benefit of having the data aggregated over all the trading exchanges. It would be a lot more expensive and harder to keep up to date if you had to aggregate the data on-chain. Also, it includes price information for more pairs and is easily extendable to fetch a lot more information if needed.
 

--- a/pricefeed/PriceFeed.sol
+++ b/pricefeed/PriceFeed.sol
@@ -467,9 +467,7 @@ contract PriceFeed is usingOraclize, ECVerify, b64, JSON_Decoder, PriceFeedProto
 
     function () payable {}
 
-    // NON-CONSTANT METHODS
-
-     function nativeProof_verify(string result, bytes proof, bytes pubkey) private returns (bool) {
+    function nativeProof_verify(string result, bytes proof, bytes pubkey) private returns (bool) {
         uint sig_len = uint(proof[1]);
         bytes memory sig = new bytes(sig_len);
         sig = copyBytes(proof, 2, sig_len, sig, 0);


### PR DESCRIPTION
- Checks if the proof is returned in not a 0-length bytes array before trying to validate it
- Adds getStatus function as per the Melon PriceFeedProtocol 
- Updates the address of the deployed contract 